### PR TITLE
Fix async setState error

### DIFF
--- a/lib/src/double_list_rows.dart
+++ b/lib/src/double_list_rows.dart
@@ -35,9 +35,13 @@ class _DoubleListRowsState<K extends Comparable<K>, T>
     super.initState();
 
     state = widget.controller._state;
-    widget.controller.addListener(() {
-      setState(() {});
-    });
+    widget.controller.addListener(_setState);
+  }
+
+  /// A wrapper around the [setState] method
+  /// that allows us to add it as a listener
+  void _setState() {
+    setState(() {});
   }
 
   @override
@@ -114,9 +118,10 @@ class _DoubleListRowsState<K extends Comparable<K>, T>
 
   @override
   void dispose() {
-    super.dispose();
-
     normalController.dispose();
     fixedController.dispose();
+    widget.controller.removeListener(_setState);
+
+    super.dispose();
   }
 }


### PR DESCRIPTION
As the listener wasn't removed from the PagedDataTableController before, the setState could be called after the _DoubleListRows has already been disposed.  This could happen when a PagedDataTable was rebuild (In my case because of changing header elements) while the PagedDataTableController._fetch was still running async.

I've also moved the super.dispose() call to the end of the dispose override as that's the intended way based on the docs

> Implementations of this method should end with a call to the inherited method, as in super.dispose().

https://api.flutter.dev/flutter/widgets/State/dispose.html