### PR TITLE
Improve CollapsibleRowColumn and add onRowPressed event

### DIFF
--- a/lib/src/column.dart
+++ b/lib/src/column.dart
@@ -271,6 +271,9 @@ final class RowSelectorColumn<K extends Comparable<K>, T>
 }
 
 /// A special [ReadOnlyTableColumn] that renders a button to open collapsed rows
+///
+/// When used on the left side of a table, use
+/// [PagedDataTable.fixedColumnCount] to indent the expanded rows correctly.
 final class CollapsibleRowColumn<K extends Comparable<K>, T>
     extends ReadOnlyTableColumn<K, T> {
   /// The icon that is shown while the row is expanded.

--- a/lib/src/column.dart
+++ b/lib/src/column.dart
@@ -273,9 +273,18 @@ final class RowSelectorColumn<K extends Comparable<K>, T>
 /// A special [ReadOnlyTableColumn] that renders a button to open collapsed rows
 final class CollapsibleRowColumn<K extends Comparable<K>, T>
     extends ReadOnlyTableColumn<K, T> {
+  /// The icon that is shown while the row is expanded.
+  final Widget expandedIcon;
+
+  /// The icon that is shown while the row is collapsed.
+  final Widget collapsedIcon;
+
   /// Creates a new [CollapsibleRowColumn].
-  CollapsibleRowColumn({super.title = const SizedBox.shrink()})
-      : super(
+  CollapsibleRowColumn({
+    super.title = const SizedBox.shrink(),
+    this.expandedIcon = const Icon(Icons.expand_circle_down_outlined),
+    this.collapsedIcon = const Icon(Icons.expand_circle_down_outlined),
+  }) : super(
           format: const AlignColumnFormat(alignment: Alignment.center),
           id: null,
           size: const FixedColumnSize(90),
@@ -286,6 +295,10 @@ final class CollapsibleRowColumn<K extends Comparable<K>, T>
 
   @override
   Widget build(BuildContext context, T item, int index) {
-    return _CollapseRowButton<K, T>(index: index);
+    return _CollapseRowButton<K, T>(
+      index: index,
+      expandedIcon: expandedIcon,
+      collapsedIcon: collapsedIcon,
+    );
   }
 }

--- a/lib/src/column_widgets.dart
+++ b/lib/src/column_widgets.dart
@@ -107,9 +107,9 @@ final class _SelectAllRowsCheckboxState<K extends Comparable<K>, T>
 
   @override
   void dispose() {
-    super.dispose();
-
     tableController.removeListener(_onTableControllerChanged);
+
+    super.dispose();
   }
 }
 
@@ -258,8 +258,8 @@ final class _TextFieldCellState<T> extends State<_TextFieldCell<T>> {
 
   @override
   void dispose() {
-    super.dispose();
     textController.dispose();
+    super.dispose();
   }
 }
 
@@ -424,8 +424,8 @@ final class _LargeTextFieldCellState<T> extends State<_LargeTextFieldCell<T>> {
 
   @override
   void dispose() {
-    super.dispose();
     textController.dispose();
+    super.dispose();
   }
 }
 
@@ -534,8 +534,8 @@ final class _EditableTextFieldOverlayState
 
   @override
   void dispose() {
-    super.dispose();
     textController.dispose();
+    super.dispose();
   }
 }
 
@@ -624,7 +624,7 @@ final class _EditableTextFieldBottomSheetState
 
   @override
   void dispose() {
-    super.dispose();
     textController.dispose();
+    super.dispose();
   }
 }

--- a/lib/src/column_widgets.dart
+++ b/lib/src/column_widgets.dart
@@ -4,15 +4,24 @@ final class _CollapseRowButton<K extends Comparable<K>, T>
     extends StatelessWidget {
   final int index;
 
-  const _CollapseRowButton({required this.index, super.key});
+  final Widget expandedIcon;
+  final Widget collapsedIcon;
+
+  const _CollapseRowButton({
+    super.key,
+    required this.index,
+    required this.expandedIcon,
+    required this.collapsedIcon,
+  });
 
   @override
   Widget build(BuildContext context) {
     final tableController = TableControllerProvider.of<K, T>(context);
 
     if (tableController._expansibleRows.containsKey(index)) {
+      final bool isExpanded = tableController._expandedRows.contains(index);
       return IconButton(
-        icon: const Icon(Icons.expand_circle_down_outlined),
+        icon: isExpanded ? expandedIcon : collapsedIcon,
         onPressed: () {
           tableController.toggleRowExpansion(index);
         },

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -526,6 +526,7 @@ final class PagedDataTableController<K extends Comparable<K>, T>
 
         totalNewItems = items.length;
         _currentDataset.clear();
+        _expansibleRows.clear();
         int index = 0;
         for (final MapEntry(key: item, value: collapsedEntries)
             in items.entries) {
@@ -535,6 +536,12 @@ final class PagedDataTableController<K extends Comparable<K>, T>
           }
           index++;
         }
+
+        // Notify all expanded rows as their data might not
+        // be available anymore and they would stay expanded
+        // with old data visible.
+        _notifyRowChangedMany(_expandedRows);
+        _expandedRows.clear();
       }
 
       _hasNextPage = nextPageToken != null;

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -96,6 +96,9 @@ final class PagedDataTableController<K extends Comparable<K>, T>
   /// The list of selected row indexes
   List<int> get selectedRows => _selectedRows.toList(growable: false);
 
+  /// The list of expanded row indexes
+  List<int> get expandedRows => _expandedRows.toList(growable: false);
+
   /// The list of selected items.
   List<T> get selectedItems => UnmodifiableListView(
       _selectedRows.map((index) => _currentDataset[index]));

--- a/lib/src/filter_bar.dart
+++ b/lib/src/filter_bar.dart
@@ -161,9 +161,9 @@ class _FilterBarState<K extends Comparable<K>, T>
 
   @override
   void dispose() {
-    super.dispose();
     chipsListController.dispose();
     controller.removeListener(_onChanged);
+    super.dispose();
   }
 }
 

--- a/lib/src/filter_widgets.dart
+++ b/lib/src/filter_widgets.dart
@@ -73,8 +73,8 @@ class _DateTimePickerState extends State<_DateTimePicker> {
 
   @override
   void dispose() {
-    super.dispose();
     textController.dispose();
+    super.dispose();
   }
 }
 
@@ -148,7 +148,7 @@ class _DateRangePickerState extends State<_DateRangePicker> {
 
   @override
   void dispose() {
-    super.dispose();
     textController.dispose();
+    super.dispose();
   }
 }

--- a/lib/src/footer_widgets.dart
+++ b/lib/src/footer_widgets.dart
@@ -45,8 +45,8 @@ class _RefreshTableState<K extends Comparable<K>, T>
 
   @override
   void dispose() {
-    super.dispose();
     controller.removeListener(_onChanged);
+    super.dispose();
   }
 }
 
@@ -118,8 +118,8 @@ class _PageSizeSelectorState<K extends Comparable<K>, T>
 
   @override
   void dispose() {
-    super.dispose();
     controller.removeListener(_onChanged);
+    super.dispose();
   }
 }
 
@@ -164,8 +164,8 @@ class _TotalItemsState<K extends Comparable<K>, T>
 
   @override
   void dispose() {
-    super.dispose();
     controller.removeListener(_onChanged);
+    super.dispose();
   }
 }
 
@@ -209,8 +209,8 @@ class _CurrentPageState<K extends Comparable<K>, T>
 
   @override
   void dispose() {
-    super.dispose();
     controller.removeListener(_onChanged);
+    super.dispose();
   }
 }
 
@@ -272,7 +272,7 @@ class _NavigationButtonsState<K extends Comparable<K>, T>
 
   @override
   void dispose() {
-    super.dispose();
     controller.removeListener(_onChanged);
+    super.dispose();
   }
 }

--- a/lib/src/header.dart
+++ b/lib/src/header.dart
@@ -157,8 +157,8 @@ final class _HeaderState<K extends Comparable<K>, T>
 
   @override
   void dispose() {
-    super.dispose();
     widget.controller.removeListener(_onControllerChanged);
+    super.dispose();
   }
 }
 

--- a/lib/src/paged_datatable.dart
+++ b/lib/src/paged_datatable.dart
@@ -67,6 +67,9 @@ final class PagedDataTable<K extends Comparable<K>, T> extends StatefulWidget {
   /// The list of filters to use.
   final List<TableFilter> filters;
 
+  /// The callback to be called when a row is pressed.
+  final void Function(T)? onRowPressed;
+
   const PagedDataTable({
     required this.columns,
     required Fetcher<K, T> this.fetcher,
@@ -79,6 +82,7 @@ final class PagedDataTable<K extends Comparable<K>, T> extends StatefulWidget {
     this.footer,
     this.filterBarChild,
     this.filters = const <TableFilter>[],
+    this.onRowPressed,
     super.key,
   });
 
@@ -94,8 +98,40 @@ final class PagedDataTable<K extends Comparable<K>, T> extends StatefulWidget {
     this.footer,
     this.filterBarChild,
     this.filters = const <TableFilter>[],
+    this.onRowPressed,
     super.key,
   });
+
+  static _PagedDataTableState<K, T> _of<K extends Comparable<K>, T>(
+    BuildContext context, {
+    bool rootNavigator = false,
+  }) {
+    // Handles the case where the input context is a PagedDataTable element.
+    _PagedDataTableState<K, T>? tableState;
+    if (context is StatefulElement &&
+        context.state is _PagedDataTableState<K, T>) {
+      tableState = context.state as _PagedDataTableState<K, T>;
+    }
+    if (rootNavigator) {
+      tableState =
+          context.findRootAncestorStateOfType<_PagedDataTableState<K, T>>() ??
+              tableState;
+    } else {
+      tableState = tableState ??
+          context.findAncestorStateOfType<_PagedDataTableState<K, T>>();
+    }
+
+    assert(() {
+      if (tableState == null) {
+        throw FlutterError(
+          "PagedDataTable operation requested with a context that"
+          "does not include a PagedDataTable.",
+        );
+      }
+      return true;
+    }());
+    return tableState!;
+  }
 
   @override
   State<StatefulWidget> createState() => _PagedDataTableState<K, T>();

--- a/lib/src/paged_datatable.dart
+++ b/lib/src/paged_datatable.dart
@@ -250,13 +250,13 @@ final class _PagedDataTableState<K extends Comparable<K>, T>
 
   @override
   void dispose() {
-    super.dispose();
     horizontalController.dispose();
     headerHorizontalController.dispose();
 
     if (selfConstructedController) {
       tableController.dispose();
     }
+    super.dispose();
   }
 
   List<double> _calculateColumnWidth(double maxWidth) {

--- a/lib/src/row.dart
+++ b/lib/src/row.dart
@@ -80,11 +80,24 @@ class _RowBuilderState<K extends Comparable<K>, T>
       );
     }
 
+    final Function(T)? onRowPressed =
+        PagedDataTable._of<K, T>(context).widget.onRowPressed;
+
     child = Column(
       mainAxisAlignment: MainAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       children: [
-        SizedBox(height: theme.rowHeight, child: child),
+        SizedBox(
+          height: theme.rowHeight,
+          child: InkWell(
+            onTap: onRowPressed != null
+                ? () {
+                    onRowPressed(controller._currentDataset[widget.index]);
+                  }
+                : null,
+            child: child,
+          ),
+        ),
         if (collapsedRows != null)
           SizeTransition(
             axisAlignment: 1.0,
@@ -95,9 +108,21 @@ class _RowBuilderState<K extends Comparable<K>, T>
                 children: collapsedRows!
                     .mapIndexed((index, collapsedRowItem) => SizedBox(
                           height: theme.rowHeight,
-                          child: Row(
+                          child: InkWell(
+                            onTap: onRowPressed != null
+                                ? () {
+                                    onRowPressed(collapsedRowItem);
+                                  }
+                                : null,
+                            child: Row(
                               children: widget.buildCollapsedCells(
-                                  context, index, collapsedRowItem, theme)),
+                                context,
+                                index,
+                                collapsedRowItem,
+                                theme,
+                              ),
+                            ),
+                          ),
                         ))
                     .toList(growable: false),
               ),

--- a/lib/src/row.dart
+++ b/lib/src/row.dart
@@ -147,10 +147,10 @@ class _RowBuilderState<K extends Comparable<K>, T>
 
   @override
   void dispose() {
-    super.dispose();
-
     controller.removeRowChangeListener(widget.index, _onRowChanged);
     expandController.dispose();
+
+    super.dispose();
   }
 }
 


### PR DESCRIPTION
This allows the user to specify widgets for both the collapsed and expanded state of the CollapsibleRowColumn.
Also I've exposed the _expandedRows variable of the TableController to allow a user to create their own CollapsibleRowColumn.
I want to improve the customizability with this as I was struggeling to work with it a bit.

I've also added a onRowPressed event to the PagedDataTable that is accessed from the _RowBuilder. I've only added a onPressed/onTap for now as thats everything I currently need. However, I do think it could be replaced by passing a `Widget Function(T)?` instead as this would not only improve customizability but also allow users to pass all kinds of gesture events without having to support each and every varient like e.g. `onSecondaryLongPressMoveUpdate`. (What even is this monstrosity ¯\\\_(ツ)\_/¯)

Wanted to hear your two cents before working on something nobody needs