### PR TITLE
🔨 Fix on table rebuild current index resets to 0

### DIFF
--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -360,7 +360,7 @@ final class PagedDataTableController<K extends Comparable<K>, T>
     assert(columns.isNotEmpty, "columns cannot be empty.");
 
     // Schedule a fetch
-    Future.microtask(_fetch);
+    Future.microtask(() =>_fetch(_currentPageIndex));
   }
 
   Future<void> _fetch([int page = 0]) async {


### PR DESCRIPTION
- Pass current page index to _fetch in microtask
- Closes issue: #57 